### PR TITLE
Make WKWebView inspectable on platforms with inspectable flag

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -440,6 +440,13 @@ RCTAutoInsetsProtocol>
     [_webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew context:nil];
     _webView.allowsBackForwardNavigationGestures = _allowsBackForwardNavigationGestures;
 
+#ifdef DEBUG
+    // https://webkit.org/blog/13936/enabling-the-inspection-of-web-content-in-apps/
+    if (@available(macOS 13.3, iOS 16.4, tvOS 16.4, *)) {
+      webView.inspectable = YES;
+    }
+#endif
+
     _webView.customUserAgent = _userAgent;
 
 #if !TARGET_OS_OSX


### PR DESCRIPTION
## Summary:

In iOS 16.4/macOS 13.3/tvOS 16.4 Apple added a new flag to WKWebView (named `isInspectable` (Swift), `inspectable` (Objective C)). This flag defaults to false which now disallows inspecting the webview. 

This PR fixes the WKWebView's created in this project so that they're inspectable when the `DEBUG` flag is set.

## Test plan:

I verified this change by installing the `react-native-webview` npm package into an existing project that I had and then applying the changes in this PR to the code in `node_modules/react-native-webview`. 

I then ran my app and navigated to one of the web views. I was able to see the web view in the Safari Debug menu and attach to it.